### PR TITLE
Fix brain duplicate sections and placeholder text

### DIFF
--- a/src/lib/brain.ts
+++ b/src/lib/brain.ts
@@ -97,7 +97,8 @@ export class Brain {
 
     if (newContent === this.content) {
       // Section didn't exist — check if heading is truly absent
-      if (!this.getSection(heading)) {
+      const headingPattern = new RegExp(`^## ${escaped}`, "m");
+      if (!this.getSection(heading) && !headingPattern.test(this.content)) {
         this.content = this.content.trimEnd() + `\n\n## ${heading}\n${content}\n`;
       }
     } else {
@@ -121,7 +122,7 @@ export class Brain {
     withFileLockSync(this.path, () => {
       this.reload();
       const history = this.getSection("Recent History");
-      const lines = history.split("\n").filter((l) => l.trim());
+      const lines = history.split("\n").filter((l) => l.startsWith("- "));
       lines.unshift(entry);
       const trimmed = lines.slice(0, MAX_EVENTS);
       this.applySectionUpdate("Recent History", trimmed.join("\n"));


### PR DESCRIPTION
## Summary
- **applySectionUpdate()**: Fixed duplicate section bug — when regex replace produces identical content, now also checks if the heading pattern exists in the raw content before appending, preventing duplicate `## Heading` blocks.
- **addEvent()**: Fixed placeholder text leaking into history — filters lines to only keep those starting with `"- "`, removing `"No events yet."` and any other non-event text.

Fixes #4

## Test plan
- [ ] Verify `updateSection()` on an existing section with identical content does not create a duplicate
- [ ] Verify `updateSection()` on a truly new section still appends correctly
- [ ] Verify `addEvent()` on a fresh brain with "No events yet." placeholder replaces it with the new event
- [ ] Run `npx tsc --noEmit` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)