### PR TITLE
Cleanup: update agents, extract shared code, fix docs

### DIFF
--- a/.claude/agents/dev.md
+++ b/.claude/agents/dev.md
@@ -14,18 +14,18 @@ You are a feature developer on the claude-vps-agent project.
 1. **Understand the task** — Read relevant files before writing code
 2. **Work in your worktree** — You are automatically in an isolated git worktree
 3. **Implement** — Write clean, focused code following project conventions
-4. **Self-check** — Run `python3 -m py_compile` on every Python file you touch
+4. **Self-check** — Run `npx tsc --noEmit` to verify TypeScript compiles
 5. **Commit** — Make clear, descriptive commits
 6. **Create PR** — Use `gh pr create` with a summary of changes and test plan
 
 ## Rules
 
-- Follow CLAUDE.md conventions (Python 3.10+, type hints, asyncio for bots)
-- All bots MUST use `lib/claude_bridge.py` — never call `claude -p` directly
+- Follow CLAUDE.md conventions (TypeScript strict mode, async/await for bots)
+- All bots MUST use `src/lib/claude-bridge.ts` — never call `claude -p` directly
 - Config via environment variables only — never hardcode secrets
 - One feature per branch. Branch name: `feature/<short-description>` or `fix/<short-description>`
 - Keep PRs focused. Don't touch files outside your scope.
-- Run `python3 -m py_compile <file>` before committing
+- Run `npx tsc --noEmit` before committing
 
 ## PR Format
 

--- a/.claude/agents/devops.md
+++ b/.claude/agents/devops.md
@@ -24,7 +24,7 @@ You are a DevOps engineer for the claude-vps-agent project.
 - All shell scripts MUST use `set -euo pipefail`
 - All shell scripts MUST be executable (`chmod +x`)
 - Systemd services run as user `claude`, not root
-- Systemd services use venv python: `/home/claude/claude-vps-agent/.venv/bin/python`
+- Systemd services use `npx tsx` for TypeScript execution
 - ReadWritePaths must include Claude's config dirs
 - Use `DEBIAN_FRONTEND=noninteractive` for apt commands
 - Quote all variables in shell scripts

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -18,7 +18,7 @@ You will receive a PR number or branch name. Your job is to review it thoroughly
 1. **Get PR context** — Run `gh pr view <number>` and `gh pr diff <number>`
 2. **Read changed files** — Understand every change
 3. **Check against CLAUDE.md** — Verify conventions are followed
-4. **Run checks** — `python3 -m py_compile` on changed Python files, `bash -n` on shell scripts
+4. **Run checks** — `npx tsc --noEmit` on changed `.ts` files, `bash -n` on shell scripts
 
 ## Review checklist
 
@@ -35,9 +35,9 @@ You will receive a PR number or branch name. Your job is to review it thoroughly
 - [ ] No sensitive data in logs
 
 ### Project conventions
-- [ ] Uses `lib/claude_bridge.py` (never raw `claude -p`)
-- [ ] Config via env vars + python-dotenv
-- [ ] Python 3.10+ type hints
+- [ ] Uses `src/lib/claude-bridge.ts` (never raw `claude -p`)
+- [ ] Config via env vars + dotenv
+- [ ] TypeScript strict mode
 - [ ] Files only modified within scope (bot agents stay in their dir)
 
 ### Consistency

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -10,11 +10,9 @@ You are a QA engineer for the claude-vps-agent project.
 
 ## Test protocol
 
-### 1. Python syntax (all .py files)
+### 1. TypeScript compilation (all .ts files)
 ```bash
-find . -name "*.py" -not -path "./.venv/*" | while read f; do
-  python3 -m py_compile "$f" && echo "OK: $f" || echo "FAIL: $f"
-done
+npx tsc --noEmit
 ```
 
 ### 2. Shell script syntax (all .sh files)
@@ -25,10 +23,10 @@ done
 ```
 
 ### 3. Import validation
-For each Python module, verify:
-- `sys.path.insert` points to the correct relative directory
-- All imports resolve (check file existence)
-- Type hints use Python 3.10+ syntax (`str | None`, not `Optional[str]`)
+For each TypeScript module, verify:
+- All imports resolve (check file existence and barrel exports in `src/lib/index.ts`)
+- Import paths use `.js` extension (required for ESM)
+- Types are correctly exported
 
 ### 4. Cross-module consistency
 - All env var names in bot code match `.env.example`

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ TELEGRAM_ALLOWED_USERS=123456789,987654321
 
 # Discord Bot (get from https://discord.com/developers/applications)
 DISCORD_BOT_TOKEN=your-discord-bot-token
+DISCORD_APP_ID=your-discord-app-id
 DISCORD_ALLOWED_USERS=123456789012345678,987654321098765432
 
 # Claude Code settings
@@ -19,6 +20,12 @@ CLAUDE_MODEL=claude-opus-4-6
 # Claude budget limit per request (optional)
 CLAUDE_MAX_BUDGET_USD=0.50
 CLAUDE_TIMEOUT_SECONDS=300
+
+# Security: restrict /project command to directories under this base path
+ALLOWED_PROJECT_BASE=/home/claude
+
+# Default project directory (fallback when CLAUDE_PROJECT_DIR is not set)
+DEFAULT_PROJECT_DIR=/home/claude/projects
 
 # Tailscale (optional)
 TAILSCALE_AUTH_KEY=tskey-auth-xxxxx

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ On a systemd-based server, these use `systemctl`. On a laptop or non-systemd mac
 
 ## Living Agent
 
-Enable with `LIVING_MODE=true` in `.env`. This mode adds persistent memory, session continuity, and proactive notifications.
+Living agent mode activates automatically when the brain system is available. This mode adds persistent memory, session continuity, and proactive notifications.
 
 **Brain system** -- Claude maintains a persistent markdown memory in `data/brain.md`, loaded before every interaction. This lets it remember context, preferences, and ongoing work across conversations.
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -9,3 +9,5 @@ export { NotificationQueue } from "./notifier.js";
 export type { Notification } from "./notifier.js";
 export { ClaudeBridge, LivingBridge } from "./claude-bridge.js";
 export type { ClaudeResponse } from "./claude-bridge.js";
+export { splitMessage } from "./message-utils.js";
+export { loadNotifyPrefs, saveNotifyPrefs } from "./notify-prefs.js";

--- a/src/lib/message-utils.ts
+++ b/src/lib/message-utils.ts
@@ -1,0 +1,38 @@
+/**
+ * message-utils.ts — Shared message splitting utility for bot modules.
+ *
+ * Splits long messages into chunks that fit within platform character limits,
+ * preferring to break at newlines or spaces for readability.
+ */
+
+/**
+ * Split a long message into chunks that fit within `limit` characters.
+ * Prefers splitting at newline boundaries, falls back to spaces, then hard cuts.
+ */
+export function splitMessage(text: string, limit: number): string[] {
+  if (text.length <= limit) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= limit) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // Try to find a good split point
+    let splitAt = remaining.lastIndexOf("\n", limit);
+    if (splitAt === -1 || splitAt < limit / 2) {
+      splitAt = remaining.lastIndexOf(" ", limit);
+    }
+    if (splitAt === -1 || splitAt < limit / 2) {
+      splitAt = limit;
+    }
+
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).replace(/^\n+/, "");
+  }
+
+  return chunks;
+}

--- a/src/lib/notify-prefs.ts
+++ b/src/lib/notify-prefs.ts
@@ -1,0 +1,40 @@
+/**
+ * notify-prefs.ts — Shared notification preference persistence for bot modules.
+ *
+ * Stores per-user opt-in/opt-out preferences for proactive notifications.
+ * Uses atomicWrite for safe concurrent access.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { atomicWrite } from "./filelock.js";
+
+/**
+ * Load notification preferences from a JSON file.
+ * Returns an empty object if the file does not exist or is malformed.
+ */
+export function loadNotifyPrefs(prefsPath: string): Record<string, boolean> {
+  const dir = path.dirname(prefsPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  if (fs.existsSync(prefsPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(prefsPath, "utf-8")) as Record<string, boolean>;
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+/**
+ * Save notification preferences to a JSON file using atomic writes.
+ */
+export function saveNotifyPrefs(prefsPath: string, prefs: Record<string, boolean>): void {
+  const dir = path.dirname(prefsPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  atomicWrite(prefsPath, JSON.stringify(prefs, null, 2));
+}


### PR DESCRIPTION
## Summary
- Update agent config files (dev, reviewer, tester, devops) from Python references to TypeScript: `tsc --noEmit` instead of `py_compile`, `src/lib/claude-bridge.ts` instead of `lib/claude_bridge.py`, `npx tsx` instead of `.venv/bin/python`
- Extract `splitMessage()` into shared `src/lib/message-utils.ts` used by both Telegram and Discord bots
- Extract `loadNotifyPrefs()`/`saveNotifyPrefs()` into shared `src/lib/notify-prefs.ts` using `atomicWrite()` for safe concurrent writes (previously used raw `fs.writeFileSync`)
- Update `src/lib/index.ts` barrel exports with new shared modules
- Add missing env vars to `.env.example`: `DISCORD_APP_ID`, `ALLOWED_PROJECT_BASE`, `DEFAULT_PROJECT_DIR`
- Fix README.md: remove incorrect `LIVING_MODE=true` reference (living mode auto-detects based on brain availability)

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [ ] Verify Telegram bot starts and `/notify` toggle works
- [ ] Verify Discord bot starts and `/notify` slash command works
- [ ] Verify message splitting works for long responses on both platforms

Fixes #8, Fixes #9, Fixes #10

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>